### PR TITLE
modified sass deprecated call in gulpfile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,8 +14,7 @@ var gulp        = require('gulp'),
 // Compile scss Files
 gulp.task('scss', ['clean_dest', 'clean_release', 'clean_zip'], function() {
     return eventstream.concat (
-      gulp.src('src/scss/fauxghost.scss')
-        .pipe(sass({style: 'expanded', quiet: false, cacheLocation: 'src/scss/.sass-cache'}))
+        sass('src/scss/fauxghost.scss',{style: 'expanded', quiet: false, cacheLocation: 'src/scss/.sass-cache'})
         .pipe(gulp.dest('dest/css'))
         .pipe(minifycss())
         .pipe(rename({suffix: '.min'}))


### PR DESCRIPTION
Modified gulp's sass call as mentioned in [this issue](https://github.com/jimbobbennett/FauxGhost/issues/1). There might be others, but `grep -lr "pipe(sass"` doesn't return anything.
