### PR TITLE
Fix code block css issue

### DIFF
--- a/src/scss/theme/_ghost.scss
+++ b/src/scss/theme/_ghost.scss
@@ -36,6 +36,9 @@
 	text-transform: uppercase;
 	opacity: 0.5;
 }
+.at_post_content pre {
+	margin-bottom: 1.25rem;
+}
 .at_featured_post {
 	display: none;
 	.featured & {


### PR DESCRIPTION
Add:
- CSS rule to apply on `pre` tags within the `at_post_content` div classes, that adds the needed 1.25rem vertical spacing on the bottom of code blocks

---

I'm not 100% sure if I placed the CSS fix in the correct file. I had also looked at the FauxGhost/src/scss/fauxghost.scss file. @jimbobbennett is this the correct location for this addition?
